### PR TITLE
Cross-build for sbt 2.0.0-RC12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04]
-        scala: [2.12]
-        java: [temurin@8]
+        scala: [2.12, 3]
+        java: [temurin@17]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     steps:
@@ -41,24 +41,24 @@ jobs:
       - name: Setup sbt
         uses: sbt/setup-sbt@v1
 
-      - name: Setup Java (temurin@8)
-        id: setup-java-temurin-8
-        if: matrix.java == 'temurin@8'
+      - name: Setup Java (temurin@17)
+        id: setup-java-temurin-17
+        if: matrix.java == 'temurin@17'
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 8
+          java-version: 17
           cache: sbt
 
       - name: sbt update
-        if: matrix.java == 'temurin@8' && steps.setup-java-temurin-8.outputs.cache-hit == 'false'
+        if: matrix.java == 'temurin@17' && steps.setup-java-temurin-17.outputs.cache-hit == 'false'
         run: sbt +update
 
       - name: Check that workflows are up to date
         run: sbt githubWorkflowCheck
 
       - name: Check headers and formatting
-        if: matrix.java == 'temurin@8' && matrix.os == 'ubuntu-22.04'
+        if: matrix.java == 'temurin@17' && matrix.os == 'ubuntu-22.04'
         run: sbt '++ ${{ matrix.scala }}' headerCheckAll scalafmtCheckAll 'project /' scalafmtSbtCheck
 
       - name: Test
@@ -68,11 +68,11 @@ jobs:
         run: sbt '++ ${{ matrix.scala }}' scripted
 
       - name: Check binary compatibility
-        if: matrix.java == 'temurin@8' && matrix.os == 'ubuntu-22.04'
+        if: matrix.java == 'temurin@17' && matrix.os == 'ubuntu-22.04'
         run: sbt '++ ${{ matrix.scala }}' mimaReportBinaryIssues
 
       - name: Generate API documentation
-        if: matrix.java == 'temurin@8' && matrix.os == 'ubuntu-22.04'
+        if: matrix.java == 'temurin@17' && matrix.os == 'ubuntu-22.04'
         run: sbt '++ ${{ matrix.scala }}' doc
 
       - name: Make target directories
@@ -97,7 +97,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04]
-        java: [temurin@8]
+        java: [temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -108,17 +108,17 @@ jobs:
       - name: Setup sbt
         uses: sbt/setup-sbt@v1
 
-      - name: Setup Java (temurin@8)
-        id: setup-java-temurin-8
-        if: matrix.java == 'temurin@8'
+      - name: Setup Java (temurin@17)
+        id: setup-java-temurin-17
+        if: matrix.java == 'temurin@17'
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 8
+          java-version: 17
           cache: sbt
 
       - name: sbt update
-        if: matrix.java == 'temurin@8' && steps.setup-java-temurin-8.outputs.cache-hit == 'false'
+        if: matrix.java == 'temurin@17' && steps.setup-java-temurin-17.outputs.cache-hit == 'false'
         run: sbt +update
 
       - name: Download target directories (2.12)
@@ -127,6 +127,16 @@ jobs:
           name: target-${{ matrix.os }}-${{ matrix.java }}-2.12
 
       - name: Inflate target directories (2.12)
+        run: |
+          tar xf targets.tar
+          rm targets.tar
+
+      - name: Download target directories (3)
+        uses: actions/download-artifact@v6
+        with:
+          name: target-${{ matrix.os }}-${{ matrix.java }}-3
+
+      - name: Inflate target directories (3)
         run: |
           tar xf targets.tar
           rm targets.tar
@@ -161,7 +171,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04]
-        java: [temurin@8]
+        java: [temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -172,21 +182,21 @@ jobs:
       - name: Setup sbt
         uses: sbt/setup-sbt@v1
 
-      - name: Setup Java (temurin@8)
-        id: setup-java-temurin-8
-        if: matrix.java == 'temurin@8'
+      - name: Setup Java (temurin@17)
+        id: setup-java-temurin-17
+        if: matrix.java == 'temurin@17'
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 8
+          java-version: 17
           cache: sbt
 
       - name: sbt update
-        if: matrix.java == 'temurin@8' && steps.setup-java-temurin-8.outputs.cache-hit == 'false'
+        if: matrix.java == 'temurin@17' && steps.setup-java-temurin-17.outputs.cache-hit == 'false'
         run: sbt +update
 
       - name: Submit Dependencies
         uses: scalacenter/sbt-dependency-submission@v2
         with:
-          modules-ignore: root_2.12
+          modules-ignore: root_2.12 root_3
           configs-ignore: test scala-tool scala-doc-tool test-internal

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -12,7 +12,8 @@ pull_request_rules:
   - or:
     - body~=labels:.*early-semver-patch
     - body~=labels:.*early-semver-minor
-  - status-success=Test (ubuntu-22.04, 2.12, temurin@8)
+  - status-success=Test (ubuntu-22.04, 2.12, temurin@17)
+  - status-success=Test (ubuntu-22.04, 3, temurin@17)
   actions:
     merge: {}
 - name: Label sbtPlugin PRs

--- a/build.sbt
+++ b/build.sbt
@@ -10,8 +10,14 @@ ThisBuild / githubWorkflowPublishTargetBranches := Seq(
   RefPredicate.StartsWith(Ref.Tag("v")),
 )
 
-ThisBuild / scalaVersion := "2.12.21"
-ThisBuild / tlJdkRelease := Some(8)
+ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.temurin("17"))
+
+val scala212 = "2.12.21"
+val scala3 = "3.8.2"
+
+ThisBuild / scalaVersion := scala212
+ThisBuild / crossScalaVersions := Seq(scala212, scala3)
+ThisBuild / tlJdkRelease := None
 ThisBuild / tlFatalWarnings := false
 
 ThisBuild / mergifyStewardConfig ~= (_.map(_.withMergeMinors(true)))
@@ -36,7 +42,6 @@ lazy val sbtPlugin = project
   .settings(
     name := "smithy-trait-codegen-sbt",
     commonSettings,
-    scalaVersion := "2.12.21",
     libraryDependencies ++= Seq(
       "software.amazon.smithy" % "smithy-trait-codegen" % "1.70.0",
       "software.amazon.smithy" % "smithy-model" % "1.70.0",
@@ -46,6 +51,7 @@ lazy val sbtPlugin = project
     pluginCrossBuild / sbtVersion := {
       scalaBinaryVersion.value match {
         case "2.12" => "1.9.8"
+        case _      => "2.0.0-RC12"
       }
     },
     scriptedLaunchOpts :=

--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ ThisBuild / githubWorkflowPublishTargetBranches := Seq(
 ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.temurin("17"))
 
 val scala212 = "2.12.21"
-val scala3 = "3.8.2"
+val scala3 = "3.8.3"
 
 ThisBuild / scalaVersion := scala212
 ThisBuild / crossScalaVersions := Seq(scala212, scala3)

--- a/sbtPlugin/src/main/scala/org/polyvariant/smithytraitcodegen/SmithyTraitCodegen.scala
+++ b/sbtPlugin/src/main/scala/org/polyvariant/smithytraitcodegen/SmithyTraitCodegen.scala
@@ -25,9 +25,6 @@ import software.amazon.smithy.model.node.ObjectNode
 import software.amazon.smithy.traitcodegen.TraitCodegenPlugin
 
 import java.io.File
-import software.amazon.smithy.model.transform.ModelTransformer
-import java.util.stream.Collectors
-import scala.collection.JavaConverters.*
 
 object SmithyTraitCodegen {
 
@@ -50,7 +47,35 @@ object SmithyTraitCodegen {
       .projectFormat[os.Path, File](p => p.toIO, file => os.Path(file))
 
     implicit val argsFmt: JsonFormat[Args] =
-      caseClass(Args.apply _, Args.unapply _)(
+      caseClass(
+        (
+          javaPackage: String,
+          smithyNamespace: String,
+          targetDir: os.Path,
+          smithySourcesDir: PathRef,
+          dependencies: List[PathRef],
+          externalProviders: List[String],
+        ) =>
+          Args(
+            javaPackage,
+            smithyNamespace,
+            targetDir,
+            smithySourcesDir,
+            dependencies,
+            externalProviders,
+          ),
+        (a: Args) =>
+          Some(
+            (
+              a.javaPackage,
+              a.smithyNamespace,
+              a.targetDir,
+              a.smithySourcesDir,
+              a.dependencies,
+              a.externalProviders,
+            )
+          ),
+      )(
         "javaPackage",
         "smithyNamespace",
         "targetDir",
@@ -65,26 +90,26 @@ object SmithyTraitCodegen {
 
   object Output {
 
-      // format: off
-      private type OutputDeconstructed = File :*: File :*: LNil
-      // format: on
+    // format: off
+    private type OutputDeconstructed = File :*: File :*: LNil
+    // format: on
 
-    implicit val outputIso = LList.iso[Output, OutputDeconstructed](
-      {
-        output: Output => ("metaDir", output.metaDir) :*:
-          ("javaDir", output.javaDir) :*:
-          LNil
-      },
-      {
-        case (_, metaDir) :*:
-            (_, javaDir) :*:
-            LNil =>
-          Output(
-            metaDir = metaDir,
-            javaDir = javaDir,
-          )
-      },
-    )
+    implicit val outputIso: IsoLList.Aux[Output, OutputDeconstructed] = LList
+      .iso[Output, OutputDeconstructed](
+        (output: Output) =>
+          ("metaDir", output.metaDir) :*:
+            ("javaDir", output.javaDir) :*:
+            LNil,
+        {
+          case (_, metaDir) :*:
+              (_, javaDir) :*:
+              LNil =>
+            Output(
+              metaDir = metaDir,
+              javaDir = javaDir,
+            )
+        },
+      )
 
   }
 

--- a/sbtPlugin/src/main/scala/org/polyvariant/smithytraitcodegen/SmithyTraitCodegenPlugin.scala
+++ b/sbtPlugin/src/main/scala/org/polyvariant/smithytraitcodegen/SmithyTraitCodegenPlugin.scala
@@ -61,6 +61,10 @@ object SmithyTraitCodegenPlugin extends AutoPlugin {
     smithyTraitCodegenExternalProviders := Nil,
     Keys.generateSmithyTraits := Def.task {
       import sbt.util.CacheImplicits.*
+      implicit val codegenCache: sbt.util.Cache[
+        SmithyTraitCodegen.Args,
+        SmithyTraitCodegen.Output,
+      ] = new sbt.util.BasicCache()
       val s = (Compile / streams).value
 
       val report = update.value
@@ -102,12 +106,12 @@ object SmithyTraitCodegenPlugin extends AutoPlugin {
     libraryDependencies ++= smithyTraitCodegenDependencies.value,
   )
 
-  private def cleanCopy(source: File, target: File) = {
+  private def cleanCopy(source: File, target: File): Seq[File] = {
     val sourcePath = os.Path(source)
     val targetPath = os.Path(target)
     os.remove.all(targetPath)
     os.copy(from = sourcePath, to = targetPath, createFolders = true)
-    os.walk(targetPath).map(_.toIO).filter(_.isFile())
+    os.walk(targetPath).map(_.toIO).filter(_.isFile()).toSeq
   }
 
   object Keys {


### PR DESCRIPTION
## Summary
- Add Scala 3.8.2 / sbt 2.0.0-RC12 to the cross matrix while keeping Scala 2.12.21 / sbt 1.9.8.
- Source kept in a single tree (no `src/main/scala-2.12` vs `scala-3` split). `sbt2-compat` is not needed — our caching API surface (`Cache.cached`, `BasicCache`, `FileInfo`, `sjsonnew`) is preserved across versions and we don't touch `Classpath` / `HashedVirtualFileRef`.
- CI runs `Test` and `scripted` per matrix entry (`scala: [2.12, 3]`); Java bumped to temurin@17 (Scala 3.8 requires JDK 17+); `tlJdkRelease` cleared.

### Source-level adjustments (Scala 2.12 + Scala 3 portable)
- `caseClass(Args.apply _, Args.unapply _)` → explicit lambdas (Scala 3 `unapply` for case classes returns the case class itself, not `Option`).
- `LList.iso` lambda needed parens around the param ascription and an explicit `IsoLList.Aux` type on the `implicit val`.
- `BasicCacheImplicits.basicCache` is a `given` in sbt 2, which Scala 3 wildcard imports don't pull into scope — instantiate `new BasicCache()` directly.
- `cleanCopy` now returns `Seq[File]` explicitly to satisfy sbt 2's stricter `Append` shapes for `sourceGenerators` / `resourceGenerators`.

## Test plan
- [x] `+sbtPlugin/compile` cross-compiles for 2.12.21 and 3.8.2 locally
- [x] `sbtPlugin/scripted` passes (sbt 1.9.8)
- [x] `++ 3.8.2 sbtPlugin/scripted` passes (sbt 2.0.0-RC12)
- [ ] CI green for both matrix entries