### PR TITLE
Add SmithyDocGenPlugin (smithy-docgen wrapper)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ Build-time tooling for working with [Smithy](https://smithy.io) models from Scal
     - [Tasks](#tasks)
     - [Configuration](#configuration)
     - [Wiring `smithyFmtCheckAll` into CI](#wiring-smithyfmtcheckall-into-ci)
+  - [`SmithyDocGenPlugin`](#smithydocgenplugin)
+    - [Usage](#usage-1)
+    - [Settings](#settings)
   - [FAQ](#faq)
     - [What's the difference between this and smithy4s?](#whats-the-difference-between-this-and-smithy4s)
 
@@ -27,7 +30,7 @@ In `project/plugins.sbt`:
 addSbtPlugin("org.polyvariant" % "smithy-scala-tools-sbt" % version)
 ```
 
-Both plugins live in this artifact — there is nothing else to add.
+All plugins live in this artifact — there is nothing else to add.
 
 ## `SmithyTraitCodegenPlugin`
 
@@ -136,6 +139,43 @@ sbt githubWorkflowGenerate
 
 > A simpler one-liner is being tracked upstream: [typelevel/sbt-typelevel#888](https://github.com/typelevel/sbt-typelevel/issues/888).
 
+## `SmithyDocGenPlugin`
+
+Generates API documentation from Smithy models using AWS's [smithy-docgen](https://github.com/smithy-lang/smithy/tree/main/smithy-docgen) plugin. Not auto-enabled — opt in on the modules that need it.
+
+### Usage
+
+In `build.sbt`:
+
+```scala
+.enablePlugins(SmithyDocGenPlugin)
+.settings(
+  smithyDocGenService := "com.example#MyService",
+  // optional, defaults to Format.Markdown
+  smithyDocGenFormat := SmithyDocGenPlugin.Format.Markdown,
+  // optional, defaults to Nil
+  smithyDocGenDependencies := Nil,
+)
+```
+
+For Sphinx-based output, use `Format.SphinxMarkdown(...)`. By default, `autoBuild = false` — `smithy-docgen` will only emit the Sphinx project files (`conf.py`, `requirements.txt`, `Makefile`, `content/`). Set `autoBuild = true` if you want `smithy-docgen` to invoke Sphinx and render the docs, but note this requires Python 3 on `PATH` and network access (the integration creates a venv and pip-installs Sphinx).
+
+By default, the plugin reads `.smithy` files from `src/main/resources/META-INF/smithy` and writes the generated documentation to `target/smithy-docgen-output/`. The `generateSmithyDocs` task runs the generation and returns the output directory.
+
+```sh
+sbt generateSmithyDocs
+```
+
+### Settings
+
+| Setting                       | Type             | Description                                                                            |
+| ----------------------------- | ---------------- | -------------------------------------------------------------------------------------- |
+| `smithyDocGenService`         | `String`         | Required. Shape ID of the service to document, e.g. `"com.example#MyService"`.         |
+| `smithyDocGenFormat`          | `Format`         | Output format ADT. `Format.Markdown` (default) or `Format.SphinxMarkdown(...)`.        |
+| `smithyDocGenDependencies`    | `List[ModuleID]` | Extra Smithy model jars to include in the assembler.                                   |
+| `smithyDocGenSourceDirectory` | `File`           | Where to look for `.smithy` files. Defaults to `Compile / resourceDirectory / META-INF / smithy`. |
+| `smithyDocGenTargetDirectory` | `File`           | Where to write generated docs. Defaults to `Compile / target`.                         |
+
 ## FAQ
 
 ### What's the difference between this and smithy4s?
@@ -148,5 +188,6 @@ They operate on a different level — they're not alternatives.
 
 - **`SmithyTraitCodegenPlugin`** is for **protocol authors** — people defining custom Smithy traits and shipping them as artifacts that downstream consumers (including smithy4s users) load via Smithy's model assembler. It generates the Java glue that makes that work.
 - **`SmithyFormatPlugin`** sits **side-by-side with smithy4s**: anyone writing `.smithy` files can use it to keep them formatted, regardless of what (if anything) consumes those models afterwards.
+- **`SmithyDocGenPlugin`** is for **anyone publishing a Smithy-modelled API** who wants browsable documentation for it — it runs AWS's `smithy-docgen` to turn the model into markdown.
 
 A project can (and often will) use both this and smithy4s.

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion := "0.2"
+ThisBuild / tlBaseVersion := "0.3"
 ThisBuild / organization := "org.polyvariant"
 ThisBuild / organizationName := "Polyvariant"
 ThisBuild / startYear := Some(2025)

--- a/build.sbt
+++ b/build.sbt
@@ -163,6 +163,7 @@ lazy val core = project
       "software.amazon.smithy" % "smithy-trait-codegen" % "1.70.0",
       "software.amazon.smithy" % "smithy-model" % "1.70.0",
       "software.amazon.smithy" % "smithy-syntax" % "1.70.0",
+      "software.amazon.smithy" % "smithy-docgen" % "1.70.0",
       "com.lihaoyi" %% "os-lib" % "0.11.8",
       "org.scalameta" %% "munit" % "1.3.0" % Test,
     ),

--- a/core/src/main/scala/org/polyvariant/smithydocgen/SmithyDocGen.scala
+++ b/core/src/main/scala/org/polyvariant/smithydocgen/SmithyDocGen.scala
@@ -48,9 +48,9 @@ object SmithyDocGen {
       * @param extraExtensions
       *   extra Sphinx extensions to enable in `conf.py`.
       * @param autoBuild
-      *   whether to automatically render the docs to the output format. Defaults to `false` in
-      *   this plugin (upstream default is `true`). When enabled, requires Python 3 on `PATH`
-      *   and network access.
+      *   whether to automatically render the docs to the output format. Defaults to `false` in this
+      *   plugin (upstream default is `true`). When enabled, requires Python 3 on `PATH` and network
+      *   access.
       */
     case class SphinxMarkdown(
       sphinxFormat: Option[String] = None,
@@ -111,7 +111,7 @@ object SmithyDocGen {
       .withMember("format", args.format.name)
 
     args.format match {
-      case Format.Markdown => base.build()
+      case Format.Markdown          => base.build()
       case s: Format.SphinxMarkdown =>
         val sphinx = sphinxNode(s)
         if (sphinx.isEmpty)

--- a/core/src/main/scala/org/polyvariant/smithydocgen/SmithyDocGen.scala
+++ b/core/src/main/scala/org/polyvariant/smithydocgen/SmithyDocGen.scala
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2025 Polyvariant
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.polyvariant.smithydocgen
+
+import software.amazon.smithy.build.FileManifest
+import software.amazon.smithy.build.PluginContext
+import software.amazon.smithy.docgen.SmithyDocPlugin
+import software.amazon.smithy.model.Model
+import software.amazon.smithy.model.node.ArrayNode
+import software.amazon.smithy.model.node.Node
+import software.amazon.smithy.model.node.ObjectNode
+
+object SmithyDocGen {
+
+  sealed trait Format extends Product with Serializable {
+    def name: String
+  }
+
+  object Format {
+
+    case object Markdown extends Format {
+      val name: String = "markdown"
+    }
+
+    /** See https://github.com/smithy-lang/smithy/tree/main/smithy-docgen for the underlying
+      * options.
+      *
+      * @param sphinxFormat
+      *   the Sphinx output format (e.g. "html", "dirhtml"). Defaults to "html" upstream.
+      * @param theme
+      *   the Sphinx theme. Defaults to "furo" upstream.
+      * @param extraDependencies
+      *   extra entries to add to the generated `requirements.txt`.
+      * @param extraExtensions
+      *   extra Sphinx extensions to enable in `conf.py`.
+      * @param autoBuild
+      *   whether to automatically render the docs to the output format. Defaults to `false` in
+      *   this plugin (upstream default is `true`). When enabled, requires Python 3 on `PATH`
+      *   and network access.
+      */
+    case class SphinxMarkdown(
+      sphinxFormat: Option[String] = None,
+      theme: Option[String] = None,
+      extraDependencies: List[String] = Nil,
+      extraExtensions: List[String] = Nil,
+      autoBuild: Boolean = false,
+    ) extends Format {
+      val name: String = "sphinx-markdown"
+    }
+
+  }
+
+  case class Args(
+    service: String,
+    format: Format,
+    targetDir: os.Path,
+    smithySourcesDir: os.Path,
+    dependencies: List[os.Path],
+  )
+
+  case class Output(outputDir: os.Path)
+
+  def generate(args: Args): Output = {
+    val outputDir = args.targetDir / "smithy-docgen-output"
+    os.remove.all(outputDir)
+    os.makeDir.all(outputDir)
+
+    val manifest = FileManifest.create(outputDir.toNIO)
+    val sharedManifest = FileManifest.create(outputDir.toNIO)
+
+    val model = args
+      .dependencies
+      .foldLeft(Model.assembler().addImport(args.smithySourcesDir.toNIO)) { case (acc, dep) =>
+        acc.addImport(dep.toNIO)
+      }
+      .assemble()
+      .unwrap()
+
+    val context = PluginContext
+      .builder()
+      .model(model)
+      .fileManifest(manifest)
+      .sharedFileManifest(sharedManifest)
+      .settings(buildSettings(args))
+      .build()
+    val plugin = new SmithyDocPlugin()
+    plugin.execute(context)
+
+    Output(outputDir = outputDir)
+  }
+
+  // See DocSettings for available top-level fields
+  private def buildSettings(args: Args): ObjectNode = {
+    val base = ObjectNode
+      .builder()
+      .withMember("service", args.service)
+      .withMember("format", args.format.name)
+
+    args.format match {
+      case Format.Markdown => base.build()
+      case s: Format.SphinxMarkdown =>
+        val sphinx = sphinxNode(s)
+        if (sphinx.isEmpty)
+          base.build()
+        else
+          base
+            .withMember(
+              "integrations",
+              ObjectNode.builder().withMember("sphinx", sphinx).build(),
+            )
+            .build()
+    }
+  }
+
+  private def sphinxNode(s: Format.SphinxMarkdown): ObjectNode = {
+    val b = ObjectNode.builder()
+    s.sphinxFormat.foreach(v => b.withMember("format", v))
+    s.theme.foreach(v => b.withMember("theme", v))
+    if (s.extraDependencies.nonEmpty)
+      b.withMember("extraDependencies", stringArray(s.extraDependencies))
+    if (s.extraExtensions.nonEmpty)
+      b.withMember("extraExtensions", stringArray(s.extraExtensions))
+    b.withMember("autoBuild", s.autoBuild)
+    b.build()
+  }
+
+  private def stringArray(values: List[String]): ArrayNode = {
+    val b = ArrayNode.builder()
+    values.foreach(v => b.withValue(Node.from(v)))
+    b.build()
+  }
+
+}

--- a/sbtPlugin/src/main/scala/org/polyvariant/smithydocgen/SmithyDocGenPlugin.scala
+++ b/sbtPlugin/src/main/scala/org/polyvariant/smithydocgen/SmithyDocGenPlugin.scala
@@ -86,7 +86,7 @@ object SmithyDocGenPlugin extends AutoPlugin {
     private implicit val formatFmt: JsonFormat[Format] = BasicJsonProtocol
       .projectFormat[Format, String](
         {
-          case SmithyDocGen.Format.Markdown => "markdown"
+          case SmithyDocGen.Format.Markdown          => "markdown"
           case s: SmithyDocGen.Format.SphinxMarkdown =>
             "sphinx-markdown" +
               s";sphinxFormat=${s.sphinxFormat.getOrElse("")}" +

--- a/sbtPlugin/src/main/scala/org/polyvariant/smithydocgen/SmithyDocGenPlugin.scala
+++ b/sbtPlugin/src/main/scala/org/polyvariant/smithydocgen/SmithyDocGenPlugin.scala
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2025 Polyvariant
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.polyvariant.smithydocgen
+
+import org.polyvariant.smithytraitcodegen.PathRef
+import sbt.*
+import sbt.plugins.JvmPlugin
+
+import java.io.File
+
+import Keys.*
+
+object SmithyDocGenPlugin extends AutoPlugin {
+  override def trigger: PluginTrigger = noTrigger
+  override def requires: Plugins = JvmPlugin
+
+  // Re-export the core Format ADT so users can write
+  // `smithyDocGenFormat := SmithyDocGenPlugin.Format.Markdown`.
+  type Format = SmithyDocGen.Format
+  val Format: SmithyDocGen.Format.type = SmithyDocGen.Format
+
+  object autoImport {
+
+    val smithyDocGenService = settingKey[String](
+      "The shape ID of the service to document (e.g. com.example#MyService)"
+    )
+
+    val smithyDocGenFormat = settingKey[Format](
+      "Output format for smithy-docgen. Defaults to Format.Markdown. " +
+        "Format.SphinxMarkdown(autoBuild = true) requires Python 3 on PATH and network access."
+    )
+
+    val smithyDocGenDependencies = settingKey[List[ModuleID]](
+      "Dependencies to be added into the docgen model"
+    )
+
+    val smithyDocGenSourceDirectory = settingKey[File](
+      "The directory where the smithy sources are located"
+    )
+
+    val smithyDocGenTargetDirectory = settingKey[File](
+      "The directory where the generated documentation will be placed"
+    )
+
+  }
+
+  import autoImport.*
+
+  // Sbt-cache key: like SmithyDocGen.Args, but path fields use PathRef so that
+  // file content participates in the cache hash. The runtime call into the core
+  // docgen converts this back to a plain SmithyDocGen.Args.
+  private case class CacheArgs(
+    service: String,
+    format: Format,
+    targetDir: os.Path,
+    smithySourcesDir: PathRef,
+    dependencies: List[PathRef],
+  )
+
+  private object CacheArgs {
+
+    import sjsonnew.*
+
+    import BasicJsonProtocol.*
+
+    private implicit val pathFormat: JsonFormat[os.Path] = BasicJsonProtocol
+      .projectFormat[os.Path, File](p => p.toIO, file => os.Path(file))
+
+    // Cache hashing only — formats are flattened to a stable string representation.
+    // SphinxMarkdown's nested options are part of the hash so they invalidate the cache
+    // when changed.
+    private implicit val formatFmt: JsonFormat[Format] = BasicJsonProtocol
+      .projectFormat[Format, String](
+        {
+          case SmithyDocGen.Format.Markdown => "markdown"
+          case s: SmithyDocGen.Format.SphinxMarkdown =>
+            "sphinx-markdown" +
+              s";sphinxFormat=${s.sphinxFormat.getOrElse("")}" +
+              s";theme=${s.theme.getOrElse("")}" +
+              s";extraDependencies=${s.extraDependencies.mkString(",")}" +
+              s";extraExtensions=${s.extraExtensions.mkString(",")}" +
+              s";autoBuild=${s.autoBuild}"
+        },
+        // Cache hashing only — never round-tripped to a Format value.
+        _ => sys.error("Format JsonFormat is hash-only and not deserializable"),
+      )
+
+    implicit val argsFmt: JsonFormat[CacheArgs] =
+      caseClass(
+        (
+          service: String,
+          format: Format,
+          targetDir: os.Path,
+          smithySourcesDir: PathRef,
+          dependencies: List[PathRef],
+        ) =>
+          CacheArgs(
+            service,
+            format,
+            targetDir,
+            smithySourcesDir,
+            dependencies,
+          ),
+        (a: CacheArgs) =>
+          Some(
+            (
+              a.service,
+              a.format,
+              a.targetDir,
+              a.smithySourcesDir,
+              a.dependencies,
+            )
+          ),
+      )(
+        "service",
+        "format",
+        "targetDir",
+        "smithySourcesDir",
+        "dependencies",
+      )
+
+  }
+
+  // sbt-shaped Output (File-based) so it can be persisted by the sbt cache.
+  case class Output(outputDir: File)
+
+  object Output {
+
+    import sjsonnew.*
+
+    // format: off
+    private type OutputDeconstructed = File :*: LNil
+    // format: on
+
+    implicit val outputIso: IsoLList.Aux[Output, OutputDeconstructed] = LList
+      .iso[Output, OutputDeconstructed](
+        (output: Output) =>
+          ("outputDir", output.outputDir) :*:
+            LNil,
+        {
+          case (_, outputDir) :*:
+              LNil =>
+            Output(outputDir = outputDir)
+        },
+      )
+
+  }
+
+  private def runDocGen(cache: CacheArgs): Output = {
+    val core = SmithyDocGen.Args(
+      service = cache.service,
+      format = cache.format,
+      targetDir = cache.targetDir,
+      smithySourcesDir = cache.smithySourcesDir.path,
+      dependencies = cache.dependencies.map(_.path),
+    )
+    val out = SmithyDocGen.generate(core)
+    Output(outputDir = out.outputDir.toIO)
+  }
+
+  override def projectSettings: Seq[Setting[?]] = Seq(
+    smithyDocGenSourceDirectory := (Compile / resourceDirectory).value / "META-INF" / "smithy",
+    smithyDocGenTargetDirectory := (Compile / target).value,
+    smithyDocGenFormat := Format.Markdown,
+    smithyDocGenDependencies := Nil,
+    Keys.generateSmithyDocs := Def.task {
+      import sbt.util.CacheImplicits.*
+      implicit val docgenCache: sbt.util.Cache[CacheArgs, Output] = new sbt.util.BasicCache()
+      val s = (Compile / streams).value
+
+      val report = update.value
+      val dependencies = smithyDocGenDependencies.value
+      val jars = dependencies.flatMap(m =>
+        report.matching(
+          moduleFilter(organization = m.organization, name = m.name, revision = m.revision)
+        )
+      )
+      require(
+        jars.size == dependencies.size,
+        "Not all dependencies required for smithy-docgen have been found",
+      )
+
+      val cacheArgs = CacheArgs(
+        service = smithyDocGenService.value,
+        format = smithyDocGenFormat.value,
+        targetDir = os.Path(smithyDocGenTargetDirectory.value),
+        smithySourcesDir = PathRef(smithyDocGenSourceDirectory.value),
+        dependencies = jars.map(PathRef(_)).toList,
+      )
+
+      val cachedDocGen =
+        Cache.cached(s.cacheStoreFactory.make("smithy-docgen")) {
+          runDocGen
+        }
+
+      cachedDocGen(cacheArgs)
+    }.value,
+    libraryDependencies ++= smithyDocGenDependencies.value,
+  )
+
+  object Keys {
+
+    val generateSmithyDocs = taskKey[Output](
+      "Run AWS smithy-docgen on the Smithy model and produce documentation"
+    )
+
+  }
+
+}

--- a/sbtPlugin/src/sbt-test/docgen/sample-docs/build.sbt
+++ b/sbtPlugin/src/sbt-test/docgen/sample-docs/build.sbt
@@ -1,0 +1,7 @@
+val root = project
+  .in(file("."))
+  .enablePlugins(SmithyDocGenPlugin)
+  .settings(
+    smithyDocGenService := "demo#Weather",
+    smithyDocGenFormat := SmithyDocGenPlugin.Format.Markdown,
+  )

--- a/sbtPlugin/src/sbt-test/docgen/sample-docs/project/plugins.sbt
+++ b/sbtPlugin/src/sbt-test/docgen/sample-docs/project/plugins.sbt
@@ -1,0 +1,5 @@
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("org.polyvariant" % "smithy-scala-tools-sbt" % x)
+  case _       => sys.error("""|The system property 'plugin.version' is not defined.
+                         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/sbtPlugin/src/sbt-test/docgen/sample-docs/src/main/resources/META-INF/smithy/weather.smithy
+++ b/sbtPlugin/src/sbt-test/docgen/sample-docs/src/main/resources/META-INF/smithy/weather.smithy
@@ -1,0 +1,21 @@
+$version: "2"
+
+namespace demo
+
+/// A simple weather service used to verify smithy-docgen integration.
+service Weather {
+    version: "2025-01-01"
+    operations: [GetCurrentTemperature]
+}
+
+/// Get the current temperature for a given city.
+operation GetCurrentTemperature {
+    input := {
+        @required
+        city: String
+    }
+    output := {
+        @required
+        temperatureCelsius: Float
+    }
+}

--- a/sbtPlugin/src/sbt-test/docgen/sample-docs/test
+++ b/sbtPlugin/src/sbt-test/docgen/sample-docs/test
@@ -1,2 +1,4 @@
 > generateSmithyDocs
-$ exists target/smithy-docgen-output/content/index.md
+# Output dir lives under (Compile / target), which differs between sbt 1 and sbt 2.
+# Locate it by name and assert its expected layout.
+$ exec sh -c 'set -eu; out=$(find target -name smithy-docgen-output -type d -print -quit); test -n "$out" || { echo "smithy-docgen-output not found"; exit 1; }; test -e "$out/content/index.md" || { echo "missing: $out/content/index.md"; exit 1; }'

--- a/sbtPlugin/src/sbt-test/docgen/sample-docs/test
+++ b/sbtPlugin/src/sbt-test/docgen/sample-docs/test
@@ -1,0 +1,2 @@
+> generateSmithyDocs
+$ exists target/smithy-docgen-output/content/index.md

--- a/sbtPlugin/src/sbt-test/docgen/sphinx-no-autobuild/build.sbt
+++ b/sbtPlugin/src/sbt-test/docgen/sphinx-no-autobuild/build.sbt
@@ -1,0 +1,7 @@
+val root = project
+  .in(file("."))
+  .enablePlugins(SmithyDocGenPlugin)
+  .settings(
+    smithyDocGenService := "demo#Weather",
+    smithyDocGenFormat := SmithyDocGenPlugin.Format.SphinxMarkdown(autoBuild = false),
+  )

--- a/sbtPlugin/src/sbt-test/docgen/sphinx-no-autobuild/project/plugins.sbt
+++ b/sbtPlugin/src/sbt-test/docgen/sphinx-no-autobuild/project/plugins.sbt
@@ -1,0 +1,5 @@
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("org.polyvariant" % "smithy-scala-tools-sbt" % x)
+  case _       => sys.error("""|The system property 'plugin.version' is not defined.
+                         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/sbtPlugin/src/sbt-test/docgen/sphinx-no-autobuild/src/main/resources/META-INF/smithy/weather.smithy
+++ b/sbtPlugin/src/sbt-test/docgen/sphinx-no-autobuild/src/main/resources/META-INF/smithy/weather.smithy
@@ -1,0 +1,21 @@
+$version: "2"
+
+namespace demo
+
+/// A simple weather service used to verify smithy-docgen integration.
+service Weather {
+    version: "2025-01-01"
+    operations: [GetCurrentTemperature]
+}
+
+/// Get the current temperature for a given city.
+operation GetCurrentTemperature {
+    input := {
+        @required
+        city: String
+    }
+    output := {
+        @required
+        temperatureCelsius: Float
+    }
+}

--- a/sbtPlugin/src/sbt-test/docgen/sphinx-no-autobuild/test
+++ b/sbtPlugin/src/sbt-test/docgen/sphinx-no-autobuild/test
@@ -1,0 +1,7 @@
+> generateSmithyDocs
+$ exists target/smithy-docgen-output/requirements.txt
+$ exists target/smithy-docgen-output/Makefile
+$ exists target/smithy-docgen-output/make.bat
+$ exists target/smithy-docgen-output/content/conf.py
+$ exists target/smithy-docgen-output/content/index.md
+$ absent target/smithy-docgen-output/venv

--- a/sbtPlugin/src/sbt-test/docgen/sphinx-no-autobuild/test
+++ b/sbtPlugin/src/sbt-test/docgen/sphinx-no-autobuild/test
@@ -1,7 +1,4 @@
 > generateSmithyDocs
-$ exists target/smithy-docgen-output/requirements.txt
-$ exists target/smithy-docgen-output/Makefile
-$ exists target/smithy-docgen-output/make.bat
-$ exists target/smithy-docgen-output/content/conf.py
-$ exists target/smithy-docgen-output/content/index.md
-$ absent target/smithy-docgen-output/venv
+# Output dir lives under (Compile / target), which differs between sbt 1 and sbt 2.
+# Locate it by name and assert its expected layout.
+$ exec sh -c 'set -eu; out=$(find target -name smithy-docgen-output -type d -print -quit); test -n "$out" || { echo "smithy-docgen-output not found"; exit 1; }; for f in requirements.txt Makefile make.bat content/conf.py content/index.md; do test -e "$out/$f" || { echo "missing: $out/$f"; exit 1; }; done; ! test -e "$out/venv" || { echo "unexpected venv at $out/venv"; exit 1; }'


### PR DESCRIPTION
## Summary
- New `SmithyDocGenPlugin` (in `sbtPlugin`) backed by a new `org.polyvariant.smithydocgen.SmithyDocGen` core class wrapping AWS's `smithy-docgen` build plugin. Same shape as `SmithyTraitCodegenPlugin` — opt-in (`enablePlugins(SmithyDocGenPlugin)`), `PathRef`-based cache, no `sourceGenerators`/`resourceGenerators` wiring (docgen produces docs, not Scala/Java).
- `smithyDocGenFormat` is a sealed ADT (`Format.Markdown` / `Format.SphinxMarkdown(...)`) so the format choice is typo-proof and `SphinxMarkdown`'s nested options (`sphinxFormat`, `theme`, `extraDependencies`, `extraExtensions`, `autoBuild`) have a typed home.
- `SphinxMarkdown.autoBuild` defaults to `false` (upstream defaults it to `true`). When `true`, the underlying integration creates a Python venv and shells out to `pip` and `sphinx-build`; defaulting it off keeps `generateSmithyDocs` a pure JVM task. The setting description and ScalaDoc note the requirement.

## Test plan
- [x] `sbt sbtPlugin/scripted` — all 7 scripted tests pass, including:
  - [x] `docgen/sample-docs` — `Format.Markdown`, asserts `content/index.md` exists.
  - [x] `docgen/sphinx-no-autobuild` — `Format.SphinxMarkdown(autoBuild = false)`, asserts the generated Sphinx project files (`requirements.txt`, `Makefile`, `make.bat`, `content/conf.py`, `content/index.md`) exist and that no `venv/` was created.
- [x] CI's existing `scripted-discover` job picks up the two new test directories automatically — no workflow changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)