### PR TITLE
Add SmithyDocGenTypelevelSitePlugin for sbt-typelevel-site integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,11 +74,11 @@ jobs:
 
       - name: Make target directories
         if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
-        run: mkdir -p core/target sbtPlugin/target project/target
+        run: mkdir -p core/target sbtPlugin/target sbtTypelevelSitePlugin/target project/target
 
       - name: Compress target directories
         if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
-        run: tar cf targets.tar core/target sbtPlugin/target project/target
+        run: tar cf targets.tar core/target sbtPlugin/target sbtTypelevelSitePlugin/target project/target
 
       - name: Upload target directories
         if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
@@ -199,7 +199,7 @@ jobs:
           configs-ignore: test scala-tool scala-doc-tool test-internal
 
   scripted-discover:
-    name: Scripted (discover tests)
+    name: Scripted (discover sbtPlugin tests)
     strategy:
       matrix:
         os: [ubuntu-22.04]
@@ -221,7 +221,7 @@ jobs:
           echo "Discovered: $tests"
 
   scripted:
-    name: Scripted
+    name: Scripted (sbtPlugin)
     needs: [scripted-discover]
     strategy:
       matrix:
@@ -253,4 +253,61 @@ jobs:
         run: sbt +update
 
       - name: Run scripted ${{ matrix.test }}
-        run: sbt '++ ${{ matrix.scala }}' 'scripted ${{ matrix.test }}'
+        run: sbt '++ ${{ matrix.scala }}' 'sbtPlugin/scripted ${{ matrix.test }}'
+
+  scripted-site-discover:
+    name: Scripted (discover sbtTypelevelSitePlugin tests)
+    strategy:
+      matrix:
+        os: [ubuntu-22.04]
+        java: [temurin@17]
+    runs-on: ${{ matrix.os }}
+    outputs:
+      tests: ${{ steps.list.outputs.tests }}
+    steps:
+      - name: Checkout current branch (full)
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: List scripted test folders
+        id: list
+        run: |
+          tests=$(find sbtTypelevelSitePlugin/src/sbt-test -mindepth 2 -maxdepth 2 -type d | sed 's|sbtTypelevelSitePlugin/src/sbt-test/||' | jq -R . | jq -sc .)
+          echo "tests=$tests" >> "$GITHUB_OUTPUT"
+          echo "Discovered: $tests"
+
+  scripted-site:
+    name: Scripted (sbtTypelevelSitePlugin)
+    needs: [scripted-site-discover]
+    strategy:
+      matrix:
+        os: [ubuntu-22.04]
+        scala: [2.12.21]
+        java: [temurin@17]
+        test: ${{ fromJSON(needs.scripted-site-discover.outputs.tests) }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout current branch (full)
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
+
+      - name: Setup Java (temurin@17)
+        id: setup-java-temurin-17
+        if: matrix.java == 'temurin@17'
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: sbt
+
+      - name: sbt update
+        if: matrix.java == 'temurin@17' && steps.setup-java-temurin-17.outputs.cache-hit == 'false'
+        run: sbt +update
+
+      - name: Run scripted ${{ matrix.test }}
+        run: sbt '++ ${{ matrix.scala }}' 'sbtTypelevelSitePlugin/scripted ${{ matrix.test }}'

--- a/build.sbt
+++ b/build.sbt
@@ -191,7 +191,25 @@ lazy val sbtPlugin = project
   )
   .enablePlugins(SbtPlugin)
 
+// sbt-typelevel-site is currently sbt 1.x only; sbt 2 work is tracked at
+// https://github.com/typelevel/sbt-typelevel/pull/872
+lazy val sbtTypelevelSitePlugin = project
+  .in(file("sbtTypelevelSitePlugin"))
+  .dependsOn(sbtPlugin)
+  .settings(
+    name := "smithy-scala-tools-sbt-typelevel-site",
+    crossScalaVersions := Seq(scala212),
+    pluginCrossBuild / sbtVersion := "1.9.8",
+    addSbtPlugin("org.typelevel" % "sbt-typelevel-site" % "0.8.5"),
+    scriptedLaunchOpts :=
+      scriptedLaunchOpts.value ++
+        Seq("-Xmx1024M", "-Dplugin.version=" + version.value),
+    scriptedBufferLog := false,
+    mimaPreviousArtifacts := Set.empty,
+  )
+  .enablePlugins(SbtPlugin)
+
 lazy val root = project
   .in(file("."))
-  .aggregate(core, sbtPlugin)
+  .aggregate(core, sbtPlugin, sbtTypelevelSitePlugin)
   .enablePlugins(NoPublishPlugin)

--- a/build.sbt
+++ b/build.sbt
@@ -22,51 +22,33 @@ ThisBuild / tlFatalWarnings := false
 
 ThisBuild / mergifyStewardConfig ~= (_.map(_.withMergeMinors(true)))
 
-// The test axis is populated at CI time by the `scripted-discover` job.
-// sbt-typelevel quotes matrixAdds values, but we need the raw GHA expression
-// `${{ fromJSON(...) }}` to render unquoted so it expands to the matrix array.
-// The placeholder below is rewritten in `githubWorkflowGenerate` below.
-// Tracked upstream: https://github.com/typelevel/sbt-typelevel/issues/887
-val scriptedTestPlaceholder = "PATCH_scripted_tests_from_needs"
-val scriptedTestExpansion = "${{ fromJSON(needs.scripted-discover.outputs.tests) }}"
-
-ThisBuild / githubWorkflowAddedJobs ++= Seq(
-  WorkflowJob(
-    id = "scripted-discover",
-    name = "Scripted (discover tests)",
-    oses = (ThisBuild / githubWorkflowOSes).value.toList.take(1),
-    scalas = List.empty,
-    javas = List((ThisBuild / githubWorkflowJavaVersions).value.head),
-    sbtStepPreamble = List.empty,
-    outputs = Map("tests" -> "steps.list.outputs.tests"),
-    steps = List(
-      WorkflowStep.CheckoutFull,
-      WorkflowStep.Run(
-        commands = List(
-          """tests=$(find sbtPlugin/src/sbt-test -mindepth 2 -maxdepth 2 -type d | sed 's|sbtPlugin/src/sbt-test/||' | jq -R . | jq -sc .)""",
-          """echo "tests=$tests" >> "$GITHUB_OUTPUT"""",
-          """echo "Discovered: $tests"""",
-        ),
-        id = Some("list"),
-        name = Some("List scripted test folders"),
-      ),
-    ),
-  ),
-  WorkflowJob(
-    id = "scripted",
-    name = "Scripted",
-    needs = List("scripted-discover"),
+// Each (jobs, patch) pair below is the full discover+run matrix for one
+// sbt-plugin module's scripted tests. sbt-typelevel-site is sbt 1.x only, so
+// its matrix runs on Scala 2.12 only.
+//
+// The placeholder/patch trick works around an upstream bug where matrixAdds
+// values are always quoted but we need the `${{ fromJSON(...) }}` expression
+// rendered unquoted. Tracked at https://github.com/typelevel/sbt-typelevel/issues/887
+ThisBuild / githubWorkflowAddedJobs ++= {
+  val oses = (ThisBuild / githubWorkflowOSes).value.toList
+  val setup = githubWorkflowJobSetup.value.toList
+  ScriptedMatrix.jobs(
+    moduleId = "sbtPlugin",
+    jobIdPrefix = "scripted",
     scalas = List(scala212, scala3),
     javas = List(JavaSpec.temurin("17")),
-    matrixAdds = Map("test" -> List(scriptedTestPlaceholder)),
-    steps =
-      githubWorkflowJobSetup.value.toList :+
-        WorkflowStep.Sbt(
-          commands = List("scripted ${{ matrix.test }}"),
-          name = Some("Run scripted ${{ matrix.test }}"),
-        ),
-  ),
-)
+    oses = oses,
+    jobSetup = setup,
+  ) ++
+    ScriptedMatrix.jobs(
+      moduleId = "sbtTypelevelSitePlugin",
+      jobIdPrefix = "scripted-site",
+      scalas = List(scala212),
+      javas = List(JavaSpec.temurin("17")),
+      oses = oses,
+      jobSetup = setup,
+    )
+}
 
 // Upstream `githubWorkflowGenerate` renders all matrix values through `wrap`,
 // which quotes the `${{ fromJSON(...) }}` expression we need for the scripted
@@ -77,12 +59,12 @@ ThisBuild / githubWorkflowAddedJobs ++= Seq(
 // sees the same form as what's on disk.
 // Tracked upstream: https://github.com/typelevel/sbt-typelevel/issues/887
 val patchScriptedMatrix: String => String =
-  yaml =>
-    yaml
-      .replace(s"[$scriptedTestPlaceholder]", scriptedTestExpansion)
-      // route the in-workflow staleness check through our patched task so it
-      // compares apples to apples
-      .replace("sbt githubWorkflowCheck", "sbt githubWorkflowCheckWithMatrixPatch")
+  ScriptedMatrix
+    .patchFor("scripted")
+    .andThen(ScriptedMatrix.patchFor("scripted-site"))
+    // route the in-workflow staleness check through our patched task so it
+    // compares apples to apples
+    .andThen(_.replace("sbt githubWorkflowCheck", "sbt githubWorkflowCheckWithMatrixPatch"))
 
 val githubWorkflowGenerateWithMatrixPatch = taskKey[Unit](
   "Generate ci.yml via sbt-typelevel, then patch the scripted matrix axis"

--- a/core/src/main/scala/org/polyvariant/smithydocgen/SmithyDocGen.scala
+++ b/core/src/main/scala/org/polyvariant/smithydocgen/SmithyDocGen.scala
@@ -65,9 +65,8 @@ object SmithyDocGen {
   }
 
   case class Args(
-    service: String,
-    format: Format,
-    targetDir: os.Path,
+    settings: ObjectNode,
+    outputDir: os.Path,
     smithySourcesDir: os.Path,
     dependencies: List[os.Path],
   )
@@ -75,7 +74,7 @@ object SmithyDocGen {
   case class Output(outputDir: os.Path)
 
   def generate(args: Args): Output = {
-    val outputDir = args.targetDir / "smithy-docgen-output"
+    val outputDir = args.outputDir
     os.remove.all(outputDir)
     os.makeDir.all(outputDir)
 
@@ -95,7 +94,7 @@ object SmithyDocGen {
       .model(model)
       .fileManifest(manifest)
       .sharedFileManifest(sharedManifest)
-      .settings(buildSettings(args))
+      .settings(args.settings)
       .build()
     val plugin = new SmithyDocPlugin()
     plugin.execute(context)
@@ -103,14 +102,19 @@ object SmithyDocGen {
     Output(outputDir = outputDir)
   }
 
-  // See DocSettings for available top-level fields
-  private def buildSettings(args: Args): ObjectNode = {
+  /** Build the settings ObjectNode from a typed `service` and `Format`.
+    * Callers that want to tweak fields the typed API doesn't expose can take
+    * the result and merge in their own members.
+    *
+    * See `software.amazon.smithy.docgen.DocSettings` for available top-level fields.
+    */
+  def buildSettings(service: String, format: Format): ObjectNode = {
     val base = ObjectNode
       .builder()
-      .withMember("service", args.service)
-      .withMember("format", args.format.name)
+      .withMember("service", service)
+      .withMember("format", format.name)
 
-    args.format match {
+    format match {
       case Format.Markdown          => base.build()
       case s: Format.SphinxMarkdown =>
         val sphinx = sphinxNode(s)

--- a/project/ScriptedMatrix.scala
+++ b/project/ScriptedMatrix.scala
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2025 Polyvariant
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import org.typelevel.sbt.gha._
+import sbt._
+
+/** Build-only helper that produces a discover+run pair of GitHub Actions
+  * workflow jobs for an sbt-plugin module's scripted tests, along with a YAML
+  * patch that fixes up the `matrixAdds` quoting so the discovered list expands
+  * as a real array.
+  *
+  * sbt-typelevel quotes everything passed via `matrixAdds`, but we need the raw
+  * `${{ fromJSON(...) }}` expression to render unquoted. We work around this by
+  * emitting a placeholder string and replacing it post-generation. The
+  * placeholder is unique per module so multiple matrices can coexist.
+  *
+  * Tracked upstream: https://github.com/typelevel/sbt-typelevel/issues/887
+  */
+object ScriptedMatrix {
+
+  private def placeholder(jobIdPrefix: String): String =
+    s"PATCH_${jobIdPrefix.replace('-', '_')}_tests_from_needs"
+
+  private def expansion(jobIdPrefix: String): String =
+    s"$${{ fromJSON(needs.$jobIdPrefix-discover.outputs.tests) }}"
+
+  /** Build a discover+run pair of [[WorkflowJob]]s for an sbt-plugin module's
+    * scripted tests. Must be called from a setting/task macro (it uses the
+    * surrounding scope's `ThisBuild / githubWorkflowOSes` and
+    * `githubWorkflowJobSetup` settings).
+    *
+    * Pair the result with a [[patchFor]] call using the same `jobIdPrefix`.
+    *
+    * @param moduleId
+    *   the sbt project id (e.g. "sbtPlugin"). Also used as the on-disk path
+    *   prefix `<moduleId>/src/sbt-test`.
+    * @param jobIdPrefix
+    *   prefix for the two generated job ids: `<prefix>-discover` and `<prefix>`.
+    * @param scalas
+    *   Scala versions to fan out over.
+    * @param javas
+    *   JVM versions for the runner.
+    * @param oses
+    *   OS list (only the first is used for the discover job; the run job uses all).
+    * @param jobSetup
+    *   the steps to run before the scripted command (typically
+    *   `githubWorkflowJobSetup.value.toList`).
+    */
+  def jobs(
+    moduleId: String,
+    jobIdPrefix: String,
+    scalas: List[String],
+    javas: List[JavaSpec],
+    oses: List[String],
+    jobSetup: List[WorkflowStep],
+  ): Seq[WorkflowJob] = {
+    val testRoot = s"$moduleId/src/sbt-test"
+
+    val discover = WorkflowJob(
+      id = s"$jobIdPrefix-discover",
+      name = s"Scripted (discover $moduleId tests)",
+      oses = oses.take(1),
+      scalas = List.empty,
+      javas = List(javas.head),
+      sbtStepPreamble = List.empty,
+      outputs = Map("tests" -> "steps.list.outputs.tests"),
+      steps = List(
+        WorkflowStep.CheckoutFull,
+        WorkflowStep.Run(
+          commands = List(
+            s"""tests=$$(find $testRoot -mindepth 2 -maxdepth 2 -type d | sed 's|$testRoot/||' | jq -R . | jq -sc .)""",
+            """echo "tests=$tests" >> "$GITHUB_OUTPUT"""",
+            """echo "Discovered: $tests"""",
+          ),
+          id = Some("list"),
+          name = Some("List scripted test folders"),
+        ),
+      ),
+    )
+
+    val run = WorkflowJob(
+      id = jobIdPrefix,
+      name = s"Scripted ($moduleId)",
+      needs = List(s"$jobIdPrefix-discover"),
+      scalas = scalas,
+      javas = javas,
+      matrixAdds = Map("test" -> List(placeholder(jobIdPrefix))),
+      steps = jobSetup :+
+        WorkflowStep.Sbt(
+          commands = List(s"$moduleId/scripted $${{ matrix.test }}"),
+          name = Some(s"Run scripted $${{ matrix.test }}"),
+        ),
+    )
+
+    Seq(discover, run)
+  }
+
+  /** YAML patch that replaces the placeholder added by [[jobs]] with the
+    * `${{ fromJSON(...) }}` expression GHA needs to expand the discovered test
+    * list as a real matrix axis. Same `jobIdPrefix` must be used here as in [[jobs]].
+    */
+  def patchFor(jobIdPrefix: String): String => String =
+    _.replace(s"[${placeholder(jobIdPrefix)}]", expansion(jobIdPrefix))
+
+}

--- a/sbtPlugin/src/main/scala/org/polyvariant/smithydocgen/SmithyDocGenPlugin.scala
+++ b/sbtPlugin/src/main/scala/org/polyvariant/smithydocgen/SmithyDocGenPlugin.scala
@@ -19,6 +19,8 @@ package org.polyvariant.smithydocgen
 import org.polyvariant.smithytraitcodegen.PathRef
 import sbt.*
 import sbt.plugins.JvmPlugin
+import software.amazon.smithy.model.node.Node
+import software.amazon.smithy.model.node.ObjectNode
 
 import java.io.File
 
@@ -56,17 +58,27 @@ object SmithyDocGenPlugin extends AutoPlugin {
       "The directory where the generated documentation will be placed"
     )
 
+    val smithyDocGenOutputDirectory = settingKey[File](
+      "The directory containing the generated documentation. " +
+        "Defaults to smithyDocGenTargetDirectory / 'smithy-docgen-output'."
+    )
+
+    val smithyDocGenSettings = settingKey[ObjectNode](
+      "The smithy-docgen settings ObjectNode. Defaults to a node derived from " +
+        "smithyDocGenService and smithyDocGenFormat. Override with `:=` for full control, " +
+        "or transform with `~=` to add/replace specific fields."
+    )
+
   }
 
   import autoImport.*
 
-  // Sbt-cache key: like SmithyDocGen.Args, but path fields use PathRef so that
-  // file content participates in the cache hash. The runtime call into the core
-  // docgen converts this back to a plain SmithyDocGen.Args.
+  // Sbt-cache key: paths use PathRef so file content participates in the hash.
+  // `settings` is the fully-resolved smithy-docgen settings node serialized to a
+  // String, which collapses service/format/extra knobs into a single stable key.
   private case class CacheArgs(
-    service: String,
-    format: Format,
-    targetDir: os.Path,
+    settings: String,
+    outputDir: os.Path,
     smithySourcesDir: PathRef,
     dependencies: List[PathRef],
   )
@@ -80,55 +92,32 @@ object SmithyDocGenPlugin extends AutoPlugin {
     private implicit val pathFormat: JsonFormat[os.Path] = BasicJsonProtocol
       .projectFormat[os.Path, File](p => p.toIO, file => os.Path(file))
 
-    // Cache hashing only — formats are flattened to a stable string representation.
-    // SphinxMarkdown's nested options are part of the hash so they invalidate the cache
-    // when changed.
-    private implicit val formatFmt: JsonFormat[Format] = BasicJsonProtocol
-      .projectFormat[Format, String](
-        {
-          case SmithyDocGen.Format.Markdown          => "markdown"
-          case s: SmithyDocGen.Format.SphinxMarkdown =>
-            "sphinx-markdown" +
-              s";sphinxFormat=${s.sphinxFormat.getOrElse("")}" +
-              s";theme=${s.theme.getOrElse("")}" +
-              s";extraDependencies=${s.extraDependencies.mkString(",")}" +
-              s";extraExtensions=${s.extraExtensions.mkString(",")}" +
-              s";autoBuild=${s.autoBuild}"
-        },
-        // Cache hashing only — never round-tripped to a Format value.
-        _ => sys.error("Format JsonFormat is hash-only and not deserializable"),
-      )
-
     implicit val argsFmt: JsonFormat[CacheArgs] =
       caseClass(
         (
-          service: String,
-          format: Format,
-          targetDir: os.Path,
+          settings: String,
+          outputDir: os.Path,
           smithySourcesDir: PathRef,
           dependencies: List[PathRef],
         ) =>
           CacheArgs(
-            service,
-            format,
-            targetDir,
+            settings,
+            outputDir,
             smithySourcesDir,
             dependencies,
           ),
         (a: CacheArgs) =>
           Some(
             (
-              a.service,
-              a.format,
-              a.targetDir,
+              a.settings,
+              a.outputDir,
               a.smithySourcesDir,
               a.dependencies,
             )
           ),
       )(
-        "service",
-        "format",
-        "targetDir",
+        "settings",
+        "outputDir",
         "smithySourcesDir",
         "dependencies",
       )
@@ -162,9 +151,8 @@ object SmithyDocGenPlugin extends AutoPlugin {
 
   private def runDocGen(cache: CacheArgs): Output = {
     val core = SmithyDocGen.Args(
-      service = cache.service,
-      format = cache.format,
-      targetDir = cache.targetDir,
+      settings = Node.parse(cache.settings).expectObjectNode(),
+      outputDir = cache.outputDir,
       smithySourcesDir = cache.smithySourcesDir.path,
       dependencies = cache.dependencies.map(_.path),
     )
@@ -175,8 +163,13 @@ object SmithyDocGenPlugin extends AutoPlugin {
   override def projectSettings: Seq[Setting[?]] = Seq(
     smithyDocGenSourceDirectory := (Compile / resourceDirectory).value / "META-INF" / "smithy",
     smithyDocGenTargetDirectory := (Compile / target).value,
+    smithyDocGenOutputDirectory := smithyDocGenTargetDirectory.value / "smithy-docgen-output",
     smithyDocGenFormat := Format.Markdown,
     smithyDocGenDependencies := Nil,
+    smithyDocGenSettings := SmithyDocGen.buildSettings(
+      smithyDocGenService.value,
+      smithyDocGenFormat.value,
+    ),
     Keys.generateSmithyDocs := Def.task {
       import sbt.util.CacheImplicits.*
       implicit val docgenCache: sbt.util.Cache[CacheArgs, Output] = new sbt.util.BasicCache()
@@ -195,9 +188,8 @@ object SmithyDocGenPlugin extends AutoPlugin {
       )
 
       val cacheArgs = CacheArgs(
-        service = smithyDocGenService.value,
-        format = smithyDocGenFormat.value,
-        targetDir = os.Path(smithyDocGenTargetDirectory.value),
+        settings = Node.printJson(smithyDocGenSettings.value),
+        outputDir = os.Path(smithyDocGenOutputDirectory.value),
         smithySourcesDir = PathRef(smithyDocGenSourceDirectory.value),
         dependencies = jars.map(PathRef(_)).toList,
       )

--- a/sbtTypelevelSitePlugin/src/main/scala/org/polyvariant/smithydocgen/typelevelsite/SmithyDocGenTypelevelSitePlugin.scala
+++ b/sbtTypelevelSitePlugin/src/main/scala/org/polyvariant/smithydocgen/typelevelsite/SmithyDocGenTypelevelSitePlugin.scala
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2025 Polyvariant
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.polyvariant.smithydocgen.typelevelsite
+
+import laika.ast.Path.Root
+import laika.config.LinkValidation
+import laika.io.model.FilePath
+import laika.sbt.LaikaPlugin
+import org.polyvariant.smithydocgen.SmithyDocGen
+import org.polyvariant.smithydocgen.SmithyDocGenPlugin
+import org.typelevel.sbt.TypelevelSitePlugin
+import sbt.*
+
+import java.io.File
+
+object SmithyDocGenTypelevelSitePlugin extends AutoPlugin {
+  override def trigger: PluginTrigger = noTrigger
+  override def requires: Plugins = TypelevelSitePlugin && SmithyDocGenPlugin
+
+  import SmithyDocGenPlugin.autoImport.*
+  import LaikaPlugin.autoImport.*
+
+  object autoImport {
+
+    val smithyDocGenSitePath = settingKey[String](
+      "Virtual path under which the generated smithy docs are mounted in the Laika site. " +
+        "Defaults to 'smithy', so docs land at /smithy/."
+    )
+
+    val smithyDocGenSiteContentDirectory = settingKey[File](
+      "The directory whose contents Laika will mount under smithyDocGenSitePath. " +
+        "Defaults to <outputDir>/build/markdown for SphinxMarkdown formats and " +
+        "<outputDir>/content for plain Markdown."
+    )
+
+  }
+
+  import autoImport.*
+
+  override def projectSettings: Seq[Setting[?]] = Seq(
+    smithyDocGenSitePath := "smithy",
+    // Default to plain markdown so users don't need Python/Sphinx. The output is
+    // raw MyST-flavored markdown — Laika passes most of it through; some directives
+    // may render literally. Users wanting cleaner output can opt into
+    //   smithyDocGenFormat := Format.SphinxMarkdown(sphinxFormat = Some("markdown"), autoBuild = true)
+    // (which adds a Python toolchain requirement at build time).
+    smithyDocGenSiteContentDirectory := {
+      val out = smithyDocGenOutputDirectory.value
+      smithyDocGenFormat.value match {
+        case _: SmithyDocGen.Format.SphinxMarkdown => out / "build" / "markdown"
+        case SmithyDocGen.Format.Markdown          => out / "content"
+      }
+    },
+    laikaInputs := laikaInputs
+      .value
+      .delegate
+      .addDirectory(
+        FilePath.fromJavaFile(smithyDocGenSiteContentDirectory.value),
+        Root / smithyDocGenSitePath.value,
+      ),
+    // smithy-docgen markdown contains internal cross-references that Laika's
+    // strict link validator can't resolve (anchor casing differs, files outside
+    // its parser scope, etc.). Exclude the mounted subtree from validation.
+    laikaConfig := laikaConfig
+      .value
+      .withConfigValue(
+        LinkValidation.Global(excluded = Seq(Root / smithyDocGenSitePath.value))
+      ),
+    // Make sure the docgen task has run (and its output exists on disk) before
+    // Laika reads the site.
+    laikaSite := laikaSite.dependsOn(SmithyDocGenPlugin.Keys.generateSmithyDocs).value,
+  )
+
+}

--- a/sbtTypelevelSitePlugin/src/sbt-test/typelevel-site/sample-site/build.sbt
+++ b/sbtTypelevelSitePlugin/src/sbt-test/typelevel-site/sample-site/build.sbt
@@ -1,0 +1,17 @@
+import laika.helium.config.HeliumIcon
+import laika.helium.config.IconLink
+
+val docs = project
+  .in(file("."))
+  .enablePlugins(SmithyDocGenPlugin, SmithyDocGenTypelevelSitePlugin)
+  .settings(
+    smithyDocGenService := "demo#Weather",
+    tlSiteIsTypelevelProject := None,
+    // Helium needs an explicit home link target. Without a git remote in the
+    // scripted-test sandbox we can't auto-derive one, so set it directly.
+    tlSiteHelium ~= {
+      _.site.topNavigationBar(
+        homeLink = IconLink.external("https://example.org/", HeliumIcon.home)
+      )
+    },
+  )

--- a/sbtTypelevelSitePlugin/src/sbt-test/typelevel-site/sample-site/docs/index.md
+++ b/sbtTypelevelSitePlugin/src/sbt-test/typelevel-site/sample-site/docs/index.md
@@ -1,0 +1,5 @@
+# Sample site
+
+This is the site root.
+
+The smithy-generated docs are mounted under [/smithy/](smithy/index.md).

--- a/sbtTypelevelSitePlugin/src/sbt-test/typelevel-site/sample-site/project/plugins.sbt
+++ b/sbtTypelevelSitePlugin/src/sbt-test/typelevel-site/sample-site/project/plugins.sbt
@@ -1,0 +1,7 @@
+sys.props.get("plugin.version") match {
+  case Some(x) =>
+    addSbtPlugin("org.polyvariant" % "smithy-scala-tools-sbt-typelevel-site" % x)
+  case _ =>
+    sys.error("""|The system property 'plugin.version' is not defined.
+                 |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/sbtTypelevelSitePlugin/src/sbt-test/typelevel-site/sample-site/src/main/resources/META-INF/smithy/weather.smithy
+++ b/sbtTypelevelSitePlugin/src/sbt-test/typelevel-site/sample-site/src/main/resources/META-INF/smithy/weather.smithy
@@ -1,0 +1,21 @@
+$version: "2"
+
+namespace demo
+
+/// A simple weather service used to verify the typelevel-site smithy-docgen integration.
+service Weather {
+    version: "2025-01-01"
+    operations: [GetCurrentTemperature]
+}
+
+/// Get the current temperature for a given city.
+operation GetCurrentTemperature {
+    input := {
+        @required
+        city: String
+    }
+    output := {
+        @required
+        temperatureCelsius: Float
+    }
+}

--- a/sbtTypelevelSitePlugin/src/sbt-test/typelevel-site/sample-site/test
+++ b/sbtTypelevelSitePlugin/src/sbt-test/typelevel-site/sample-site/test
@@ -1,0 +1,9 @@
+# Build the typelevel site, which runs mdoc + laika and depends on
+# generateSmithyDocs (so our smithy docs end up mounted at /smithy/).
+> tlSite
+
+# The mdoc-generated root page should be at the site root.
+$ exists target/docs/site/index.html
+
+# The smithy-generated content should be mounted under /smithy/.
+$ exists target/docs/site/smithy/index.html


### PR DESCRIPTION
## Summary
- New `sbtTypelevelSitePlugin` module providing `SmithyDocGenTypelevelSitePlugin`, which mounts smithy-docgen output as a Laika sub-page (default `/smithy/`) in a sbt-typelevel-site project
- New `smithyDocGenSettings: SettingKey[ObjectNode]` on `SmithyDocGenPlugin`, default-derived from service+format. Users override with `:=` or `~=`. Cache key is the serialized settings node
- `smithyDocGenOutputDirectory: SettingKey[File]` exposed so plugins can reference the output as a setting (needed because Laika's `laikaInputs` is a SettingKey and can't `.value` a TaskKey)
- Scripted test `typelevel-site/sample-site` covering the wiring with plain markdown (no Python required)

## Notes
- sbt-typelevel-site is sbt 1.x only — the new module is pinned to scala 2.12 / sbt 1.x. sbt 2 work tracked upstream at https://github.com/typelevel/sbt-typelevel/pull/872
- Default format is plain `Format.Markdown` so the integration works without a Python toolchain. `Format.SphinxMarkdown` remains opt-in for cleaner output

## Still TODO before merge
- [ ] CI: scripted-discover + scripted job for the new module (sbt 1.x only)
- [ ] Dogfood: \`docs/\` sub-build that consumes our own plugins via \`publishLocal\`
- [ ] CI: build docs on PRs; deploy after publish on main

## Test plan
- [x] Existing \`docgen/sample-docs\` scripted test still passes after refactor
- [x] New \`typelevel-site/sample-site\` scripted test passes locally
- [ ] Add scripted job to ci.yml (next commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)