### PR TITLE
Refactor SmithyDocGenPlugin to expose smithy-docgen settings as a sbt setting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,7 @@ jobs:
           configs-ignore: test scala-tool scala-doc-tool test-internal
 
   scripted-discover:
-    name: Scripted (discover tests)
+    name: Scripted (discover sbtPlugin tests)
     strategy:
       matrix:
         os: [ubuntu-22.04]
@@ -221,7 +221,7 @@ jobs:
           echo "Discovered: $tests"
 
   scripted:
-    name: Scripted
+    name: Scripted (sbtPlugin)
     needs: [scripted-discover]
     strategy:
       matrix:
@@ -253,4 +253,4 @@ jobs:
         run: sbt +update
 
       - name: Run scripted ${{ matrix.test }}
-        run: sbt '++ ${{ matrix.scala }}' 'scripted ${{ matrix.test }}'
+        run: sbt '++ ${{ matrix.scala }}' 'sbtPlugin/scripted ${{ matrix.test }}'

--- a/build.sbt
+++ b/build.sbt
@@ -22,50 +22,17 @@ ThisBuild / tlFatalWarnings := false
 
 ThisBuild / mergifyStewardConfig ~= (_.map(_.withMergeMinors(true)))
 
-// The test axis is populated at CI time by the `scripted-discover` job.
-// sbt-typelevel quotes matrixAdds values, but we need the raw GHA expression
-// `${{ fromJSON(...) }}` to render unquoted so it expands to the matrix array.
-// The placeholder below is rewritten in `githubWorkflowGenerate` below.
-// Tracked upstream: https://github.com/typelevel/sbt-typelevel/issues/887
-val scriptedTestPlaceholder = "PATCH_scripted_tests_from_needs"
-val scriptedTestExpansion = "${{ fromJSON(needs.scripted-discover.outputs.tests) }}"
-
-ThisBuild / githubWorkflowAddedJobs ++= Seq(
-  WorkflowJob(
-    id = "scripted-discover",
-    name = "Scripted (discover tests)",
-    oses = (ThisBuild / githubWorkflowOSes).value.toList.take(1),
-    scalas = List.empty,
-    javas = List((ThisBuild / githubWorkflowJavaVersions).value.head),
-    sbtStepPreamble = List.empty,
-    outputs = Map("tests" -> "steps.list.outputs.tests"),
-    steps = List(
-      WorkflowStep.CheckoutFull,
-      WorkflowStep.Run(
-        commands = List(
-          """tests=$(find sbtPlugin/src/sbt-test -mindepth 2 -maxdepth 2 -type d | sed 's|sbtPlugin/src/sbt-test/||' | jq -R . | jq -sc .)""",
-          """echo "tests=$tests" >> "$GITHUB_OUTPUT"""",
-          """echo "Discovered: $tests"""",
-        ),
-        id = Some("list"),
-        name = Some("List scripted test folders"),
-      ),
-    ),
-  ),
-  WorkflowJob(
-    id = "scripted",
-    name = "Scripted",
-    needs = List("scripted-discover"),
-    scalas = List(scala212, scala3),
-    javas = List(JavaSpec.temurin("17")),
-    matrixAdds = Map("test" -> List(scriptedTestPlaceholder)),
-    steps =
-      githubWorkflowJobSetup.value.toList :+
-        WorkflowStep.Sbt(
-          commands = List("scripted ${{ matrix.test }}"),
-          name = Some("Run scripted ${{ matrix.test }}"),
-        ),
-  ),
+// Discover+run matrix for the sbt plugin's scripted tests. The placeholder/patch
+// trick works around an upstream bug where matrixAdds values are always quoted
+// but we need the `${{ fromJSON(...) }}` expression rendered unquoted.
+// Tracked at https://github.com/typelevel/sbt-typelevel/issues/887
+ThisBuild / githubWorkflowAddedJobs ++= ScriptedMatrix.jobs(
+  moduleId = "sbtPlugin",
+  jobIdPrefix = "scripted",
+  scalas = List(scala212, scala3),
+  javas = List(JavaSpec.temurin("17")),
+  oses = (ThisBuild / githubWorkflowOSes).value.toList,
+  jobSetup = githubWorkflowJobSetup.value.toList,
 )
 
 // Upstream `githubWorkflowGenerate` renders all matrix values through `wrap`,
@@ -76,13 +43,11 @@ ThisBuild / githubWorkflowAddedJobs ++= Seq(
 // The CI workflow's "up to date" check calls the patched check task so it
 // sees the same form as what's on disk.
 // Tracked upstream: https://github.com/typelevel/sbt-typelevel/issues/887
-val patchScriptedMatrix: String => String =
-  yaml =>
-    yaml
-      .replace(s"[$scriptedTestPlaceholder]", scriptedTestExpansion)
-      // route the in-workflow staleness check through our patched task so it
-      // compares apples to apples
-      .replace("sbt githubWorkflowCheck", "sbt githubWorkflowCheckWithMatrixPatch")
+val patchScriptedMatrix: String => String = ScriptedMatrix
+  .patchFor("scripted")
+  // route the in-workflow staleness check through our patched task so it
+  // compares apples to apples
+  .andThen(_.replace("sbt githubWorkflowCheck", "sbt githubWorkflowCheckWithMatrixPatch"))
 
 val githubWorkflowGenerateWithMatrixPatch = taskKey[Unit](
   "Generate ci.yml via sbt-typelevel, then patch the scripted matrix axis"

--- a/core/src/main/scala/org/polyvariant/smithydocgen/SmithyDocGen.scala
+++ b/core/src/main/scala/org/polyvariant/smithydocgen/SmithyDocGen.scala
@@ -65,9 +65,8 @@ object SmithyDocGen {
   }
 
   case class Args(
-    service: String,
-    format: Format,
-    targetDir: os.Path,
+    settings: ObjectNode,
+    outputDir: os.Path,
     smithySourcesDir: os.Path,
     dependencies: List[os.Path],
   )
@@ -75,7 +74,7 @@ object SmithyDocGen {
   case class Output(outputDir: os.Path)
 
   def generate(args: Args): Output = {
-    val outputDir = args.targetDir / "smithy-docgen-output"
+    val outputDir = args.outputDir
     os.remove.all(outputDir)
     os.makeDir.all(outputDir)
 
@@ -95,7 +94,7 @@ object SmithyDocGen {
       .model(model)
       .fileManifest(manifest)
       .sharedFileManifest(sharedManifest)
-      .settings(buildSettings(args))
+      .settings(args.settings)
       .build()
     val plugin = new SmithyDocPlugin()
     plugin.execute(context)
@@ -103,14 +102,18 @@ object SmithyDocGen {
     Output(outputDir = outputDir)
   }
 
-  // See DocSettings for available top-level fields
-  private def buildSettings(args: Args): ObjectNode = {
+  /** Build the settings ObjectNode from a typed `service` and `Format`. Callers that want to tweak
+    * fields the typed API doesn't expose can take the result and merge in their own members.
+    *
+    * See `software.amazon.smithy.docgen.DocSettings` for available top-level fields.
+    */
+  def buildSettings(service: String, format: Format): ObjectNode = {
     val base = ObjectNode
       .builder()
-      .withMember("service", args.service)
-      .withMember("format", args.format.name)
+      .withMember("service", service)
+      .withMember("format", format.name)
 
-    args.format match {
+    format match {
       case Format.Markdown          => base.build()
       case s: Format.SphinxMarkdown =>
         val sphinx = sphinxNode(s)

--- a/project/ScriptedMatrix.scala
+++ b/project/ScriptedMatrix.scala
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2025 Polyvariant
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import org.typelevel.sbt.gha._
+import sbt._
+
+/** Build-only helper that produces a discover+run pair of GitHub Actions workflow jobs for an
+  * sbt-plugin module's scripted tests, along with a YAML patch that fixes up the `matrixAdds`
+  * quoting so the discovered list expands as a real array.
+  *
+  * sbt-typelevel quotes everything passed via `matrixAdds`, but we need the raw
+  * `${{ fromJSON(...) }}` expression to render unquoted. We work around this by emitting a
+  * placeholder string and replacing it post-generation. The placeholder is unique per module so
+  * multiple matrices can coexist.
+  *
+  * Tracked upstream: https://github.com/typelevel/sbt-typelevel/issues/887
+  */
+object ScriptedMatrix {
+
+  private def placeholder(jobIdPrefix: String): String =
+    s"PATCH_${jobIdPrefix.replace('-', '_')}_tests_from_needs"
+
+  private def expansion(jobIdPrefix: String): String =
+    s"$${{ fromJSON(needs.$jobIdPrefix-discover.outputs.tests) }}"
+
+  /** Build a discover+run pair of [[WorkflowJob]]s for an sbt-plugin module's scripted tests. Must
+    * be called from a setting/task macro (it uses the surrounding scope's
+    * `ThisBuild / githubWorkflowOSes` and `githubWorkflowJobSetup` settings).
+    *
+    * Pair the result with a [[patchFor]] call using the same `jobIdPrefix`.
+    *
+    * @param moduleId
+    *   the sbt project id (e.g. "sbtPlugin"). Also used as the on-disk path prefix
+    *   `<moduleId>/src/sbt-test`.
+    * @param jobIdPrefix
+    *   prefix for the two generated job ids: `<prefix>-discover` and `<prefix>`.
+    * @param scalas
+    *   Scala versions to fan out over.
+    * @param javas
+    *   JVM versions for the runner.
+    * @param oses
+    *   OS list (only the first is used for the discover job; the run job uses all).
+    * @param jobSetup
+    *   the steps to run before the scripted command (typically
+    *   `githubWorkflowJobSetup.value.toList`).
+    */
+  def jobs(
+    moduleId: String,
+    jobIdPrefix: String,
+    scalas: List[String],
+    javas: List[JavaSpec],
+    oses: List[String],
+    jobSetup: List[WorkflowStep],
+  ): Seq[WorkflowJob] = {
+    val testRoot = s"$moduleId/src/sbt-test"
+
+    val discover = WorkflowJob(
+      id = s"$jobIdPrefix-discover",
+      name = s"Scripted (discover $moduleId tests)",
+      oses = oses.take(1),
+      scalas = List.empty,
+      javas = List(javas.head),
+      sbtStepPreamble = List.empty,
+      outputs = Map("tests" -> "steps.list.outputs.tests"),
+      steps = List(
+        WorkflowStep.CheckoutFull,
+        WorkflowStep.Run(
+          commands = List(
+            s"""tests=$$(find $testRoot -mindepth 2 -maxdepth 2 -type d | sed 's|$testRoot/||' | jq -R . | jq -sc .)""",
+            """echo "tests=$tests" >> "$GITHUB_OUTPUT"""",
+            """echo "Discovered: $tests"""",
+          ),
+          id = Some("list"),
+          name = Some("List scripted test folders"),
+        ),
+      ),
+    )
+
+    val run = WorkflowJob(
+      id = jobIdPrefix,
+      name = s"Scripted ($moduleId)",
+      needs = List(s"$jobIdPrefix-discover"),
+      scalas = scalas,
+      javas = javas,
+      matrixAdds = Map("test" -> List(placeholder(jobIdPrefix))),
+      steps =
+        jobSetup :+
+          WorkflowStep.Sbt(
+            commands = List(s"$moduleId/scripted $${{ matrix.test }}"),
+            name = Some(s"Run scripted $${{ matrix.test }}"),
+          ),
+    )
+
+    Seq(discover, run)
+  }
+
+  /** YAML patch that replaces the placeholder added by [[jobs]] with the `${{ fromJSON(...) }}`
+    * expression GHA needs to expand the discovered test list as a real matrix axis. Same
+    * `jobIdPrefix` must be used here as in [[jobs]].
+    */
+  def patchFor(jobIdPrefix: String): String => String =
+    _.replace(s"[${placeholder(jobIdPrefix)}]", expansion(jobIdPrefix))
+
+}

--- a/sbtPlugin/src/main/scala/org/polyvariant/smithydocgen/SmithyDocGenPlugin.scala
+++ b/sbtPlugin/src/main/scala/org/polyvariant/smithydocgen/SmithyDocGenPlugin.scala
@@ -19,6 +19,8 @@ package org.polyvariant.smithydocgen
 import org.polyvariant.smithytraitcodegen.PathRef
 import sbt.*
 import sbt.plugins.JvmPlugin
+import software.amazon.smithy.model.node.Node
+import software.amazon.smithy.model.node.ObjectNode
 
 import java.io.File
 
@@ -56,17 +58,27 @@ object SmithyDocGenPlugin extends AutoPlugin {
       "The directory where the generated documentation will be placed"
     )
 
+    val smithyDocGenOutputDirectory = settingKey[File](
+      "The directory containing the generated documentation. " +
+        "Defaults to smithyDocGenTargetDirectory / 'smithy-docgen-output'."
+    )
+
+    val smithyDocGenSettings = settingKey[ObjectNode](
+      "The smithy-docgen settings ObjectNode. Defaults to a node derived from " +
+        "smithyDocGenService and smithyDocGenFormat. Override with `:=` for full control, " +
+        "or transform with `~=` to add/replace specific fields."
+    )
+
   }
 
   import autoImport.*
 
-  // Sbt-cache key: like SmithyDocGen.Args, but path fields use PathRef so that
-  // file content participates in the cache hash. The runtime call into the core
-  // docgen converts this back to a plain SmithyDocGen.Args.
+  // Sbt-cache key: paths use PathRef so file content participates in the hash.
+  // `settings` is the fully-resolved smithy-docgen settings node serialized to a
+  // String, which collapses service/format/extra knobs into a single stable key.
   private case class CacheArgs(
-    service: String,
-    format: Format,
-    targetDir: os.Path,
+    settings: String,
+    outputDir: os.Path,
     smithySourcesDir: PathRef,
     dependencies: List[PathRef],
   )
@@ -80,55 +92,32 @@ object SmithyDocGenPlugin extends AutoPlugin {
     private implicit val pathFormat: JsonFormat[os.Path] = BasicJsonProtocol
       .projectFormat[os.Path, File](p => p.toIO, file => os.Path(file))
 
-    // Cache hashing only — formats are flattened to a stable string representation.
-    // SphinxMarkdown's nested options are part of the hash so they invalidate the cache
-    // when changed.
-    private implicit val formatFmt: JsonFormat[Format] = BasicJsonProtocol
-      .projectFormat[Format, String](
-        {
-          case SmithyDocGen.Format.Markdown          => "markdown"
-          case s: SmithyDocGen.Format.SphinxMarkdown =>
-            "sphinx-markdown" +
-              s";sphinxFormat=${s.sphinxFormat.getOrElse("")}" +
-              s";theme=${s.theme.getOrElse("")}" +
-              s";extraDependencies=${s.extraDependencies.mkString(",")}" +
-              s";extraExtensions=${s.extraExtensions.mkString(",")}" +
-              s";autoBuild=${s.autoBuild}"
-        },
-        // Cache hashing only — never round-tripped to a Format value.
-        _ => sys.error("Format JsonFormat is hash-only and not deserializable"),
-      )
-
     implicit val argsFmt: JsonFormat[CacheArgs] =
       caseClass(
         (
-          service: String,
-          format: Format,
-          targetDir: os.Path,
+          settings: String,
+          outputDir: os.Path,
           smithySourcesDir: PathRef,
           dependencies: List[PathRef],
         ) =>
           CacheArgs(
-            service,
-            format,
-            targetDir,
+            settings,
+            outputDir,
             smithySourcesDir,
             dependencies,
           ),
         (a: CacheArgs) =>
           Some(
             (
-              a.service,
-              a.format,
-              a.targetDir,
+              a.settings,
+              a.outputDir,
               a.smithySourcesDir,
               a.dependencies,
             )
           ),
       )(
-        "service",
-        "format",
-        "targetDir",
+        "settings",
+        "outputDir",
         "smithySourcesDir",
         "dependencies",
       )
@@ -162,9 +151,8 @@ object SmithyDocGenPlugin extends AutoPlugin {
 
   private def runDocGen(cache: CacheArgs): Output = {
     val core = SmithyDocGen.Args(
-      service = cache.service,
-      format = cache.format,
-      targetDir = cache.targetDir,
+      settings = Node.parse(cache.settings).expectObjectNode(),
+      outputDir = cache.outputDir,
       smithySourcesDir = cache.smithySourcesDir.path,
       dependencies = cache.dependencies.map(_.path),
     )
@@ -175,8 +163,13 @@ object SmithyDocGenPlugin extends AutoPlugin {
   override def projectSettings: Seq[Setting[?]] = Seq(
     smithyDocGenSourceDirectory := (Compile / resourceDirectory).value / "META-INF" / "smithy",
     smithyDocGenTargetDirectory := (Compile / target).value,
+    smithyDocGenOutputDirectory := smithyDocGenTargetDirectory.value / "smithy-docgen-output",
     smithyDocGenFormat := Format.Markdown,
     smithyDocGenDependencies := Nil,
+    smithyDocGenSettings := SmithyDocGen.buildSettings(
+      smithyDocGenService.value,
+      smithyDocGenFormat.value,
+    ),
     Keys.generateSmithyDocs := Def.task {
       import sbt.util.CacheImplicits.*
       implicit val docgenCache: sbt.util.Cache[CacheArgs, Output] = new sbt.util.BasicCache()
@@ -195,9 +188,8 @@ object SmithyDocGenPlugin extends AutoPlugin {
       )
 
       val cacheArgs = CacheArgs(
-        service = smithyDocGenService.value,
-        format = smithyDocGenFormat.value,
-        targetDir = os.Path(smithyDocGenTargetDirectory.value),
+        settings = Node.printJson(smithyDocGenSettings.value),
+        outputDir = os.Path(smithyDocGenOutputDirectory.value),
         smithySourcesDir = PathRef(smithyDocGenSourceDirectory.value),
         dependencies = jars.map(PathRef(_)).toList,
       )


### PR DESCRIPTION
## Summary
- Replace `SmithyDocGen.Args.service`/`format` with `settings: ObjectNode` so callers can override or transform the smithy-docgen settings node directly. Defaults are unchanged: `smithyDocGenSettings` is derived from `smithyDocGenService` + `smithyDocGenFormat` via `SmithyDocGen.buildSettings`. Use `~=` to tweak specific keys, `:=` for full control.
- Expose `smithyDocGenOutputDirectory` as a setting so downstream plugins can reference the output dir without invoking the docgen task.
- Cache key is the JSON-serialized settings node — collapses service/format/extras into one stable hashable input. Drops the ad-hoc `Format` JsonFormat that flattened SphinxMarkdown options to a delimited string.
- Extract the discover+run scripted CI job pair (and the matrix-quoting workaround for [typelevel/sbt-typelevel#887](https://github.com/typelevel/sbt-typelevel/issues/887)) into a build-only helper at `project/ScriptedMatrix.scala`. Currently used once but ready for reuse if/when more sbt-plugin modules are added.

## Test plan
- [x] Existing `docgen/sample-docs` scripted test passes against the refactor
- [x] `githubWorkflowGenerateWithMatrixPatch` produces the same shape of ci.yml as before (with `sbtPlugin/scripted` now explicitly scoped — minor improvement)

## Notes
This replaces #41, which tried to also add an `SmithyDocGenTypelevelSitePlugin`. That work hit too many edge cases in Laika's link resolution to be worth shipping in the same PR — parking it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)