### PR TITLE
Update sbt plugin cross-build to sbt 2.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         run: sbt +update
 
       - name: Check that workflows are up to date
-        run: sbt githubWorkflowCheck
+        run: sbt githubWorkflowCheckWithMatrixPatch
 
       - name: Check headers and formatting
         if: matrix.java == 'temurin@17' && matrix.os == 'ubuntu-22.04'
@@ -253,7 +253,7 @@ jobs:
         os: [ubuntu-22.04]
         scala: [2.12.21, 3.8.4]
         java: [temurin@17]
-        test: [PATCH_scripted_tests_from_needs]
+        test: ${{ fromJSON(needs.scripted-discover.outputs.tests) }}
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -310,7 +310,7 @@ jobs:
         os: [ubuntu-22.04]
         scala: [2.12.21, 3.8.4]
         java: [temurin@17]
-        test: [PATCH_scripted_smithy4s_tests_from_needs]
+        test: ${{ fromJSON(needs.scripted-smithy4s-discover.outputs.tests) }}
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)

--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,3 +1,15 @@
 updates.cooldown = {
   minimumAge = "7 days"
 }
+
+# Scala Steward's built-in sbt-github-actions integration regenerates ci.yml
+# with a bare `sbt githubWorkflowGenerate`, which reverts the scripted matrix
+# axis to the unsubstituted `PATCH_*_from_needs` placeholder (see build.sbt).
+# This post-update hook re-runs generation through the patched task so the
+# committed ci.yml keeps the `${{ fromJSON(...) }}` form. The hook runs after
+# every update, so it also corrects the workflow whenever the built-in
+# regeneration fires.
+postUpdateHooks = [{
+  command = ["sbt", "githubWorkflowGenerateWithMatrixPatch"],
+  commitMessage = "Regenerate ci.yml with scripted matrix patch"
+}]

--- a/build.sbt
+++ b/build.sbt
@@ -156,7 +156,7 @@ lazy val sbtPlugin = project
     pluginCrossBuild / sbtVersion := {
       scalaBinaryVersion.value match {
         case "2.12" => "1.9.8"
-        case _      => "2.0.0-RC12"
+        case _      => "2.0.0"
       }
     },
     scriptedLaunchOpts :=
@@ -180,7 +180,7 @@ lazy val sbtPluginSmithy4s = project
     pluginCrossBuild / sbtVersion := {
       scalaBinaryVersion.value match {
         case "2.12" => "1.9.8"
-        case _      => "2.0.0-RC12"
+        case _      => "2.0.0"
       }
     },
     scriptedLaunchOpts :=


### PR DESCRIPTION
Three changes:

1. **sbt 2.0.0 bump** — bump the Scala 3 plugin cross-build target in both `sbtPlugin` and `sbtPluginSmithy4s` from `2.0.0-RC12` to the released `2.0.0`. The `2.12` / sbt 1.9.8 path is unchanged.

2. **Regenerate ci.yml** — the committed `ci.yml` had its scripted matrix axis reverted to the unsubstituted `PATCH_*_from_needs` placeholder, making scripted jobs fail with `Expected '/'`. Regenerated via `githubWorkflowGenerateWithMatrixPatch` so the axes use `${{ fromJSON(...) }}`.

3. **Steward post-update hook** — root cause of #2: Scala Steward's `Update scala3-library to 3.8.4` (#52) ran a bare `sbt githubWorkflowGenerate` as its "Regenerate GitHub Actions workflow" step, which reverts the patch. That PR merged red, poisoning `main`. Add a `postUpdateHook` so Steward re-runs `githubWorkflowGenerateWithMatrixPatch` after every update and the patch is preserved. Validated with `scala-steward validate-repo-config`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)